### PR TITLE
[Feat] ChatHistoryPanel 컴포넌트 구현

### DIFF
--- a/src/components/support/supportInfo/info/InfoPanel.tsx
+++ b/src/components/support/supportInfo/info/InfoPanel.tsx
@@ -1,8 +1,13 @@
 'use client';
 import React, { useState } from 'react';
-import { ClientInfoType, OrderHistoryItemType } from '@/types/support';
+import {
+  ChatHistoryItemType,
+  ClientInfoType,
+  OrderHistoryItemType,
+} from '@/types/support';
 import ClientInfoPanel from './clientInfo/ClientInfoPanel';
 import OrderHistoryPanel from './orderHistory/OrderHistoryPanel';
+import ChatHistoryPanel from './chatHistoty/ChatHistoryPanel';
 
 const MOCK_CLIENT_INFO: ClientInfoType = {
   clientName: '홍길동',
@@ -45,6 +50,22 @@ const MOCK_ORDER_HISTORY: OrderHistoryItemType[] = [
   },
 ];
 
+const MOCK_CHAT_HISTORY: ChatHistoryItemType[] = [
+  {
+    id: 1,
+    createdAt: '2025년 5월 1일 오후 12:43',
+    category: '배달 문의',
+    summaryText: '요청이 받아들여지지 못함. 주문을 취소해서 상담을 마무리함',
+  },
+  {
+    id: 2,
+    createdAt: '2025년 5월 1일 오후 12:43',
+    category: '환불 문의',
+    summaryText:
+      '회원님이 주문 취소를 요청했으나 주문이 이미 접수되어서 요청이 받아들여지지 못함. 주문을 취소해서 상담을 마무리함',
+  },
+];
+
 const tabs = [
   { id: 'info', label: '고객 정보' },
   { id: 'orders', label: '주문 내역' },
@@ -56,6 +77,7 @@ const InfoPanel = () => {
   const [activeTab, setActiveTab] = useState('info');
   const [clientInfo] = useState(MOCK_CLIENT_INFO);
   const [orderHistory] = useState(MOCK_ORDER_HISTORY);
+  const [chatHistory] = useState(MOCK_CHAT_HISTORY);
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -70,7 +92,9 @@ const InfoPanel = () => {
           </div>
         );
       case 'history':
-        return (
+        return chatHistory.length > 0 ? (
+          <ChatHistoryPanel chatHistories={chatHistory} />
+        ) : (
           <div className="h-full p-4 flex items-center justify-center text-textGray font-medium">
             상담 이력 내용
           </div>
@@ -96,7 +120,7 @@ const InfoPanel = () => {
             className={`w-[25%] inline-flex flex-1 items-center justify-center py-3 text-lg transition-colors ${
               activeTab === tab.id
                 ? 'text-mainColor bg-white font-bold '
-                : 'text-textBlak bg-[#ebebeb] font-medium hover:text-textBlack'
+                : 'text-textBlak bg-[#ebebeb] font-medium hover:bg-[#dcdcdc] hover:text-mainColor'
             }`}
           >
             {tab.label}

--- a/src/components/support/supportInfo/info/chatHistoty/ChatHistoryDetail.tsx
+++ b/src/components/support/supportInfo/info/chatHistoty/ChatHistoryDetail.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const ChatHistoryDetail = ({
+  summaryText,
+  onClose,
+}: {
+  summaryText: string;
+  onClose: () => void;
+}) => {
+  return (
+    <div
+      className="flex flex-col gap-3 m-4 mt-0 p-3 bg-bgLightBlue rounded-lg overflow-y-auto cursor-pointer"
+      onClick={onClose}
+    >
+      <div className="text-textBlack text-base font-bold border-b border-zinc-300 pb-2">
+        상담 내용 요약
+      </div>
+      <div className="text-textBlack text-sm leading-relaxed font-medium">
+        {summaryText}
+      </div>
+    </div>
+  );
+};
+
+export default ChatHistoryDetail;

--- a/src/components/support/supportInfo/info/chatHistoty/ChatHistoryPanel.tsx
+++ b/src/components/support/supportInfo/info/chatHistoty/ChatHistoryPanel.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ChatHistotyItem from './ChatHistotyItem';
+import { ChatHistoryItemType } from '@/types/support';
+
+const ChatHistoryPanel = ({
+  chatHistories,
+}: {
+  chatHistories: ChatHistoryItemType[];
+  //   handleChatHistoryClick: (id: number) => void;
+}) => {
+  return (
+    <div className="flex flex-col">
+      {chatHistories.map((chatHistory) => (
+        <ChatHistotyItem key={chatHistory.id} chatHistory={chatHistory} />
+      ))}
+    </div>
+  );
+};
+
+export default ChatHistoryPanel;

--- a/src/components/support/supportInfo/info/chatHistoty/ChatHistotyItem.tsx
+++ b/src/components/support/supportInfo/info/chatHistoty/ChatHistotyItem.tsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { ChatHistoryItemType } from '@/types/support';
+import ChatHistoryDetail from './ChatHistoryDetail';
+import { TiArrowSortedDown } from 'react-icons/ti';
+
+interface ChatHistotyItemProps {
+  chatHistory: ChatHistoryItemType;
+}
+
+const ChatHistotyItem: React.FC<ChatHistotyItemProps> = ({ chatHistory }) => {
+  const [isChatHistoryOpen, setIsChatHistoryOpen] = useState(false);
+
+  const handleToggle = () => {
+    setIsChatHistoryOpen((prev) => !prev);
+  };
+
+  const containerStyle = `border-b border-zinc-100 ${
+    isChatHistoryOpen ? 'hover:bg-gray-100' : ''
+  }`;
+
+  const headerStyle = `px-5 py-4 flex flex-row items-center justify-between gap-1 hover:bg-gray-100 cursor-pointer ${
+    isChatHistoryOpen ? 'hover:bg-transparent' : ''
+  }`;
+
+  const arrowStyle = `w-5 h-5 transition-transform duration-200 ${
+    isChatHistoryOpen ? 'rotate-180' : ''
+  }`;
+
+  return (
+    <div className={containerStyle}>
+      <div className={headerStyle} onClick={handleToggle}>
+        <div className="flex flex-col items-start gap-1">
+          <div className="text-textBlack text-base font-semibold">
+            {chatHistory.category}
+          </div>
+          <div className="text-textLightGray text-sm font-medium">
+            {chatHistory.createdAt}
+          </div>
+        </div>
+        <TiArrowSortedDown className={arrowStyle} />
+      </div>
+
+      {isChatHistoryOpen && (
+        <ChatHistoryDetail
+          summaryText={chatHistory.summaryText}
+          onClose={handleToggle}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ChatHistotyItem;

--- a/src/components/support/supportInfo/info/clientInfo/ClientInfoPanel.tsx
+++ b/src/components/support/supportInfo/info/clientInfo/ClientInfoPanel.tsx
@@ -51,7 +51,10 @@ export default function ClientInfoPanel({ clientInfo }: ClientInfoPanelProps) {
               {info.value}
             </div>
             {isCoupon && info.isToggle && (
-              <button onClick={info.isToggle ? info.onToggle : undefined}>
+              <button
+                onClick={info.isToggle ? info.onToggle : undefined}
+                className="hover:bg-gray-100 rounded-full p-1 transition"
+              >
                 <TiArrowSortedDown
                   className={`w-5 h-5 transition-transform duration-200 ${
                     info.isOpen ? 'rotate-180' : ''

--- a/src/components/support/supportInfo/info/clientInfo/CouponDropdown.tsx
+++ b/src/components/support/supportInfo/info/clientInfo/CouponDropdown.tsx
@@ -6,7 +6,7 @@ interface CouponDropdownProps {
 
 const CouponDropdown = ({ couponInfo }: CouponDropdownProps) => {
   return (
-    <div className="flex flex-col gap-2 ml-4 mt-2 p-3 bg-gray-50 rounded-lg overflow-y-auto max-h-[200px]">
+    <div className="flex flex-col gap-2 ml-4 mt-2 p-3 bg-bgLightBlue rounded-lg overflow-y-auto max-h-[200px]">
       {couponInfo.map((coupon) => (
         <div
           key={coupon.currency}

--- a/src/components/support/supportInfo/info/orderHistory/OrderItem.tsx
+++ b/src/components/support/supportInfo/info/orderHistory/OrderItem.tsx
@@ -23,7 +23,7 @@ const OrderItem = ({ order }: OrderItemProps) => {
   return (
     <button
       type="button"
-      className="w-full px-5 py-4 flex flex-col gap-5 items-start border-b border-lineGray last:border-b-0"
+      className="w-full px-5 py-4 flex flex-col gap-5 items-start border-b border-zinc-100 hover:bg-gray-100"
       onClick={() => console.log(`${order.orderNumber} 클릭`)}
     >
       <header className="flex gap-2 items-center">

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -39,3 +39,10 @@ export interface OrderHistoryItemType {
   storeImage: string;
   orderNumber: string;
 }
+
+export interface ChatHistoryItemType {
+  id: number;
+  createdAt: string;
+  category: string;
+  summaryText: string;
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #19 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1. ChatHistoryItem 컴포넌트 생성
- 화살표 아이콘을 통해 상세 정보가 있다는 것을 시각적으로 안내
- 클릭 시 `ChatHistoryDetail` 컴포넌트가 토글 방식으로 열림

### 2. ChatHistoryDetail 컴포넌트 생성 (토글 형식)
- `ChatHistoryItem` 클릭 시 해당 상담 내용 요약을 표시

### 3. ChatHistoryPanel 컴포넌트 생성
- 상담 내역 전체를 감싸는 `부모 컴포넌트` 역할

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->

| ChatHistoryItem (토글 false) | ChatHistoryItem + ChatHistoryDetail (토글 true) | ChatHistoryPanel |
|--|--|--|
| <img width="503" alt="스크린샷 2025-07-07 오전 1 21 20" src="https://github.com/user-attachments/assets/cec179be-6a1a-4778-83a6-ca28842f55cc" /> | <img width="504" alt="스크린샷 2025-07-07 오전 1 21 32" src="https://github.com/user-attachments/assets/1ace1a6f-708c-401c-b797-cb030e11ef42" /> | <img width="505" alt="스크린샷 2025-07-07 오전 1 21 47" src="https://github.com/user-attachments/assets/d68601f0-289d-41c7-bb1e-121e1c4853d2" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
