### PR TITLE
[Feat] ChatMemoPanel 컴포넌트 구현

### DIFF
--- a/src/components/support/supportInfo/info/InfoPanel.tsx
+++ b/src/components/support/supportInfo/info/InfoPanel.tsx
@@ -8,6 +8,7 @@ import {
 import ClientInfoPanel from './clientInfo/ClientInfoPanel';
 import OrderHistoryPanel from './orderHistory/OrderHistoryPanel';
 import ChatHistoryPanel from './chatHistoty/ChatHistoryPanel';
+import ChatMemoPanel from './chatMemo/ChatMemoPanel';
 
 const MOCK_CLIENT_INFO: ClientInfoType = {
   clientName: '홍길동',
@@ -66,6 +67,8 @@ const MOCK_CHAT_HISTORY: ChatHistoryItemType[] = [
   },
 ];
 
+const MOCK_CHAT_MEMO = '상담 메모하는 공간~~~';
+
 const tabs = [
   { id: 'info', label: '고객 정보' },
   { id: 'orders', label: '주문 내역' },
@@ -78,6 +81,7 @@ const InfoPanel = () => {
   const [clientInfo] = useState(MOCK_CLIENT_INFO);
   const [orderHistory] = useState(MOCK_ORDER_HISTORY);
   const [chatHistory] = useState(MOCK_CHAT_HISTORY);
+  const [chatMemo] = useState(MOCK_CHAT_MEMO);
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -100,10 +104,10 @@ const InfoPanel = () => {
           </div>
         );
       case 'memo':
-        return (
-          <div className="h-full p-4 flex items-center justify-center text-textGray font-medium">
-            상담 메모 내용
-          </div>
+        return chatMemo ? (
+          <ChatMemoPanel hasMemo={true} initialMemo={chatMemo} />
+        ) : (
+          <ChatMemoPanel hasMemo={false} />
         );
       default:
         return null;

--- a/src/components/support/supportInfo/info/chatMemo/ChatMemoPanel.tsx
+++ b/src/components/support/supportInfo/info/chatMemo/ChatMemoPanel.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import React, { useState } from 'react';
+import { PLACEHOLDERS } from '@/lib/constants/placeholders';
+
+interface ChatMemoPanelProps {
+  initialMemo?: string;
+  hasMemo: boolean;
+}
+
+const ChatMemoPanel = ({ initialMemo = '', hasMemo }: ChatMemoPanelProps) => {
+  const [isEditing, setIsEditing] = useState(!hasMemo);
+  const [memo, setMemo] = useState(initialMemo);
+
+  const handleEditToggle = () => {
+    setIsEditing(true);
+  };
+
+  const handleSave = () => {
+    console.log('메모 저장', memo);
+    setIsEditing(false);
+  };
+
+  return (
+    <div className="px-5 py-4 flex flex-col gap-2">
+      <label htmlFor="memo" className="text-textBlack text-base font-bold">
+        상담 메모
+      </label>
+      <textarea
+        id="memo"
+        className={`w-full px-5 py-3 border border-lineGray rounded-[1.25rem] resize-none shadow-inputShadow text-sm font-medium focus:outline-none ${
+          isEditing ? 'focus:border-[1px] focus:border-mainColor' : ''
+        }`}
+        rows={8}
+        placeholder={PLACEHOLDERS.CHAT_MEMO}
+        value={memo}
+        onChange={(e) => setMemo(e.target.value)}
+        readOnly={!isEditing}
+      />
+      <div className="flex justify-end gap-2">
+        {isEditing ? (
+          <button
+            onClick={handleSave}
+            className="px-4 py-2 bg-mainColor text-white text-sm font-semibold rounded-[10px] hover:bg-mainColor/80"
+          >
+            저장
+          </button>
+        ) : (
+          <button
+            onClick={handleEditToggle}
+            className="px-4 py-2 bg-gray-100 text-textBlack text-sm font-semibold rounded-[10px] border hover:bg-gray-200"
+          >
+            수정
+          </button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ChatMemoPanel;

--- a/src/lib/constants/placeholders.ts
+++ b/src/lib/constants/placeholders.ts
@@ -1,6 +1,7 @@
 export const PLACEHOLDERS = {
-  ID_INPUT: '아이디를 입력해주세요',
-  PW_INPUT: '비밀번호를 입력해주세요',
-  CHAT_INPUT: '메시지를 입력해주세요',
+  ID_INPUT: '아이디를 입력해 주세요',
+  PW_INPUT: '비밀번호를 입력해 주세요',
+  CHAT_INPUT: '메시지를 입력해 주세요',
   CLIENT_SEARCH: '고객 검색',
+  CHAT_MEMO: '상담 중 메모를 입력해 주세요',
 };


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #21 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1. 상담 메모 textarea에 사용될 placeholder 상수화

### 2. ChatMemoPanel 컴포넌트 구현
- `initialMemo`: 이미 작성한 메모 데이터가 있는 경우에만 부모 컴포넌트로부터 넘겨받아 화면에 표시
- `hasMemo`: 메모 존재 여부에 따라 초기 수정 모드를 결정 (true일 경우 수정 모드 아님, false일 경우 바로 수정 가능)
- 수정 버튼 클릭 시 편집 모드로 전환되며 저장 버튼 클릭 시 메모 저장 후 읽기 모드로 전환

### 3. InfoPanel 컴포넌트에 ChatMemoPanel 불러오기.
- 메모 데이터가 있는 경우 `hasMemo = true`와 함께 `initialMemo`를 전달
- 메모 데이터가 없는 경우 `hasMemo = false`만 전달하여 빈 입력창 표시
- hasMemo 여부에 따라 ChatMemoPanel에서 초기 상태를 읽기 + 수정 모드로 구분하여 렌더링


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| ChatMemoPanel `hasMemo = true` | ChatMemoPanel `hasMemo = false` |
|--|--|
| <img width="502" alt="스크린샷 2025-07-09 오후 6 49 27" src="https://github.com/user-attachments/assets/50f98665-54f3-415e-b35c-8dda9b5a9141" /> | <img width="503" alt="스크린샷 2025-07-09 오후 6 50 02" src="https://github.com/user-attachments/assets/c5264ef8-a4d4-4b95-965e-51d62af28cef" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
