### PR TITLE
[Feat] OrderDetail 컴포넌트 구현

### DIFF
--- a/src/components/support/chatRoom/ChatRoomPanel.tsx
+++ b/src/components/support/chatRoom/ChatRoomPanel.tsx
@@ -130,7 +130,7 @@ const ChatRoomPanel = ({
   };
 
   return (
-    <div className="flex flex-col w-[35%] border-r border-lineGray bg-bgLightBlue">
+    <div className="flex flex-col w-[40%] border-r border-lineGray bg-bgLightBlue">
       <ChatHeader chatInfo={chatInfo} />
       <ChatRoom messages={messages} />
       <ChatInput

--- a/src/components/support/supportInfo/SupportInfoPanel.tsx
+++ b/src/components/support/supportInfo/SupportInfoPanel.tsx
@@ -8,7 +8,7 @@ interface SupportInfoPanelProps {
 
 const SupportInfoPanel = ({ setInputMessage }: SupportInfoPanelProps) => {
   return (
-    <div className="flex flex-col w-[35%] border-r border-lineGray bg-white">
+    <div className="flex flex-col w-[30%] border-r border-lineGray bg-white">
       <InfoPanel />
       <RecommendationPanel setInputMessage={setInputMessage} />
     </div>

--- a/src/components/support/supportInfo/info/InfoPanel.tsx
+++ b/src/components/support/supportInfo/info/InfoPanel.tsx
@@ -27,7 +27,7 @@ const MOCK_CLIENT_INFO: ClientInfoType = {
 const MOCK_ORDER_HISTORY: OrderHistoryItemType[] = [
   {
     orderDate: '2025년 5월 1일 오후 12:43',
-    orderStatus: '배달중',
+    deliveryStatus: '배달중',
     storeName: '교촌치킨',
     storeImage:
       'https://i.pinimg.com/736x/b0/a8/61/b0a8616afe69d927283130b6d67a2f75.jpg',
@@ -35,7 +35,7 @@ const MOCK_ORDER_HISTORY: OrderHistoryItemType[] = [
   },
   {
     orderDate: '2025년 5월 1일 오후 12:43',
-    orderStatus: '배달중',
+    deliveryStatus: '배달중',
     storeName: '교촌치킨',
     storeImage:
       'https://i.pinimg.com/736x/b0/a8/61/b0a8616afe69d927283130b6d67a2f75.jpg',
@@ -43,7 +43,7 @@ const MOCK_ORDER_HISTORY: OrderHistoryItemType[] = [
   },
   {
     orderDate: '2025년 5월 1일 오후 12:43',
-    orderStatus: '배달중',
+    deliveryStatus: '배달중',
     storeName: '교촌치킨',
     storeImage:
       'https://i.pinimg.com/736x/b0/a8/61/b0a8616afe69d927283130b6d67a2f75.jpg',

--- a/src/components/support/supportInfo/info/chatHistoty/ChatHistoryDetail.tsx
+++ b/src/components/support/supportInfo/info/chatHistoty/ChatHistoryDetail.tsx
@@ -9,7 +9,7 @@ const ChatHistoryDetail = ({
 }) => {
   return (
     <div
-      className="flex flex-col gap-3 m-4 mt-0 p-3 bg-bgLightBlue rounded-lg overflow-y-auto cursor-pointer"
+      className="flex flex-col gap-3 m-4 mt-0 p-3 bg-gray-50 rounded-lg overflow-y-auto cursor-pointer"
       onClick={onClose}
     >
       <div className="text-textBlack text-base font-bold border-b border-zinc-300 pb-2">

--- a/src/components/support/supportInfo/info/clientInfo/CouponDropdown.tsx
+++ b/src/components/support/supportInfo/info/clientInfo/CouponDropdown.tsx
@@ -6,7 +6,7 @@ interface CouponDropdownProps {
 
 const CouponDropdown = ({ couponInfo }: CouponDropdownProps) => {
   return (
-    <div className="flex flex-col gap-2 ml-4 mt-2 p-3 bg-bgLightBlue rounded-lg overflow-y-auto max-h-[200px]">
+    <div className="flex flex-col gap-2 ml-4 mt-2 p-3 bg-gray-50 rounded-lg overflow-y-auto max-h-[200px]">
       {couponInfo.map((coupon) => (
         <div
           key={coupon.currency}

--- a/src/components/support/supportInfo/info/orderHistory/DetailContent.tsx
+++ b/src/components/support/supportInfo/info/orderHistory/DetailContent.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { OrderDetailItemType } from '@/types/support';
+
+interface DetailContentProps {
+  orderDetail: OrderDetailItemType;
+  activeTab: string;
+}
+
+const DetailContent = ({ orderDetail, activeTab }: DetailContentProps) => {
+  const grayInfoStyle = 'text-textGray font-medium text-sm';
+  const blackSemiBoldInfoStyle = 'text-textBlack font-semibold';
+  const blackBoldInfoStyle = 'text-textBlack font-bold text-lg';
+
+  const renderOrderMenu = () => (
+    <div className="flex flex-col p-3 bg-gray-50 rounded-lg">
+      {orderDetail?.orderMenuSummary?.orderMenuInfos.map((menu, index) => (
+        <div key={index} className="flex justify-between items-center pb-2">
+          <div className="flex flex-row gap-3 items-center">
+            <span className="text-textBlack font-medium">
+              {menu.menuName} ({menu.menuPrice.toLocaleString()}원)
+            </span>
+            <span className="text-textGray text-sm">{menu.menuQuantity}개</span>
+          </div>
+          <span className={blackSemiBoldInfoStyle}>
+            {menu.totalMenuPrice.toLocaleString()}원
+          </span>
+        </div>
+      ))}
+      <div className="border-t pt-3 flex justify-between items-center">
+        <span className={blackBoldInfoStyle}>총 주문 금액</span>
+        <span className={`${blackBoldInfoStyle} text-[#5573E2]`}>
+          {orderDetail?.orderMenuSummary?.totalPrice.toLocaleString()}원
+        </span>
+      </div>
+    </div>
+  );
+
+  const renderPaymentInfo = () => (
+    <div className="flex flex-col p-3 bg-gray-50 rounded-lg gap-2">
+      <div className="flex justify-between items-center border-b pb-3">
+        <span className={blackBoldInfoStyle}>총 결제 금액</span>
+        <span className={`${blackBoldInfoStyle} text-[#5573E2]`}>
+          {orderDetail.paymentInfo.paidAmount.toLocaleString()}원
+        </span>
+      </div>
+      <div className="flex flex-col">
+        <div className="flex justify-between items-center">
+          <span className={blackSemiBoldInfoStyle}>총 금액</span>
+          <span className={blackSemiBoldInfoStyle}>
+            {orderDetail.paymentInfo.totalAmount.toLocaleString()}원
+          </span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className={grayInfoStyle}>메뉴 금액</span>
+          <span className={grayInfoStyle}>
+            {orderDetail.paymentInfo.menuPrice.toLocaleString()}원
+          </span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className={grayInfoStyle}>배달팁</span>
+          <span className={grayInfoStyle}>
+            {orderDetail.paymentInfo.deliveryFee.toLocaleString()}원
+          </span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className={grayInfoStyle}>결제 방법</span>
+          <span className={grayInfoStyle}>
+            {orderDetail.paymentInfo.method}
+          </span>
+        </div>
+      </div>
+
+      {(orderDetail.paymentInfo.discountAmount !== 0 ||
+        orderDetail.paymentInfo.couponAmount !== 0) && (
+        <div className="flex flex-col border-t pt-3">
+          {orderDetail.paymentInfo.discountAmount !== 0 && (
+            <div className="flex justify-between items-center">
+              <span className={blackSemiBoldInfoStyle}>할인 금액</span>
+              <span className={`${blackSemiBoldInfoStyle} text-textRed`}>
+                {orderDetail.paymentInfo.discountAmount.toLocaleString()}원
+              </span>
+            </div>
+          )}
+          {orderDetail.paymentInfo.couponAmount !== 0 && (
+            <div className="flex justify-between items-center">
+              <span className={grayInfoStyle}>쿠폰 할인</span>
+              <span className={grayInfoStyle}>
+                {orderDetail.paymentInfo.couponAmount.toLocaleString()}원
+              </span>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderDeliveryInfo = () => (
+    <div className="flex flex-col bg-gray-50 rounded-lg gap-1 px-3">
+      <div className="flex flex-col border-b py-3">
+        <span className={blackSemiBoldInfoStyle}>전화번호</span>
+        <p className="text-textGray text-sm mt-1 ">
+          {orderDetail.deliveryInfo.phone}
+        </p>
+      </div>
+      <div className="flex flex-col border-b py-3">
+        <span className={blackSemiBoldInfoStyle}>배달 주소</span>
+        <p className="text-textGray text-sm mt-1">
+          {orderDetail.deliveryInfo.address}
+        </p>
+      </div>
+      {orderDetail.deliveryInfo.deliveryNote && (
+        <div className="flex flex-col border-b py-3">
+          <span className={blackSemiBoldInfoStyle}>배달 요청사항</span>
+          <p className="text-textGray text-sm mt-1">
+            {orderDetail.deliveryInfo.deliveryNote}
+          </p>
+        </div>
+      )}
+      {orderDetail.deliveryInfo.restaurantNote && (
+        <div className="flex flex-col py-3">
+          <span className={blackSemiBoldInfoStyle}>매장 요청사항</span>
+          <p className="text-textGray text-sm mt-1">
+            {orderDetail.deliveryInfo.restaurantNote}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case '주문 메뉴':
+        return renderOrderMenu();
+      case '결제 정보':
+        return renderPaymentInfo();
+      case '배달 정보':
+        return renderDeliveryInfo();
+      default:
+        return renderOrderMenu();
+    }
+  };
+
+  return <div className="bg-white">{renderContent()}</div>;
+};
+
+export default DetailContent;

--- a/src/components/support/supportInfo/info/orderHistory/DetailTabs.tsx
+++ b/src/components/support/supportInfo/info/orderHistory/DetailTabs.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface DetailTabsProps {
+  activeTab: string;
+  onTabChange: (tab: string) => void;
+}
+
+const DetailTabs = ({ activeTab, onTabChange }: DetailTabsProps) => {
+  const tabs = ['주문 메뉴', '결제 정보', '배달 정보'];
+
+  return (
+    <div className="flex justify-start items-center gap-3">
+      {tabs.map((tab) => (
+        <button
+          key={tab}
+          onClick={() => onTabChange(tab)}
+          className={`px-2 py-1 text-xs rounded-2xl font-semibold transition-colors ${
+            activeTab === tab
+              ? 'text-white bg-mainColor border border-mainColor'
+              : 'text-mainColor border border-mainColor hover:bg-mainColor/80 hover:text-white'
+          }`}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default DetailTabs;

--- a/src/components/support/supportInfo/info/orderHistory/OrderDetail.tsx
+++ b/src/components/support/supportInfo/info/orderHistory/OrderDetail.tsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+import DetailTabs from './DetailTabs';
+import DetailContent from './DetailContent';
+import { OrderDetailItemType } from '@/types/support';
+
+const OrderDetail = ({ orderDetail }: { orderDetail: OrderDetailItemType }) => {
+  const [activeTab, setActiveTab] = useState('주문 메뉴');
+
+  return (
+    <div className="w-full flex flex-col px-5 py-2.5 gap-2 border-b border-zinc-100">
+      <DetailTabs activeTab={activeTab} onTabChange={setActiveTab} />
+      <DetailContent orderDetail={orderDetail} activeTab={activeTab} />
+    </div>
+  );
+};
+
+export default OrderDetail;

--- a/src/components/support/supportInfo/info/orderHistory/OrderHistoryPanel.tsx
+++ b/src/components/support/supportInfo/info/orderHistory/OrderHistoryPanel.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+'use client';
+
+import React, { useState } from 'react';
 import OrderItem from './OrderItem';
 import { OrderHistoryItemType } from '@/types/support';
 
@@ -6,11 +8,67 @@ interface OrderHistoryPanelProps {
   orderHistory: OrderHistoryItemType[];
 }
 
+const orderMenu = {
+  orderNumber: 'T22A0000DW',
+  orderDate: '2025-07-09T14:30:00',
+  deliveryStatus: '배달중',
+  orderMenuSummary: {
+    orderMenuInfos: [
+      {
+        menuName: '레드허니콤보',
+        menuQuantity: 1,
+        menuPrice: 20000,
+        totalMenuPrice: 20000,
+      },
+      {
+        menuName: '웨지감자',
+        menuQuantity: 2,
+        menuPrice: 4000,
+        totalMenuPrice: 8000,
+      },
+    ],
+    totalPrice: 28000,
+  },
+  paymentInfo: {
+    paidAmount: 17000, // 결제 금액
+    method: '배민페이머니', // 결제 방법
+    totalAmount: 22000, // 총 금액
+    menuPrice: 19000, // 메뉴 금액
+    deliveryFee: 3000, // 배달팁
+    discountAmount: -5000, // 할인 금액
+    couponAmount: -5000, // 쿠폰
+    // discountAmount: 0, // 할인 금액
+    // couponAmount: 0, // 쿠폰
+  },
+  deliveryInfo: {
+    phone: '010-1234-5678',
+    address: '서울시 강남구 테헤란로 123',
+    deliveryNote: '문 앞에 놓아주세요',
+    restaurantNote: '수저x',
+  },
+};
+
 const OrderHistoryPanel = ({ orderHistory }: OrderHistoryPanelProps) => {
+  const [orderDetail] = useState(orderMenu);
+  const [isTabMenuOpen, setIsTabMenuOpen] = useState(false);
+
+  const handleOrderItemClick = (orderNumber: string) => {
+    console.log(orderNumber);
+    setIsTabMenuOpen(!isTabMenuOpen);
+  };
+
   return (
     <div>
-      {orderHistory.map((order, index) => (
-        <OrderItem key={index} order={order} />
+      {orderHistory.map((orderInfo, index) => (
+        <OrderItem
+          key={index}
+          orderInfo={orderInfo}
+          orderDetail={orderDetail}
+          onHandleOrderItemClick={() =>
+            handleOrderItemClick(orderInfo.orderNumber)
+          }
+          isTabMenuOpen={isTabMenuOpen}
+        />
       ))}
     </div>
   );

--- a/src/components/support/supportInfo/info/orderHistory/OrderItem.tsx
+++ b/src/components/support/supportInfo/info/orderHistory/OrderItem.tsx
@@ -1,12 +1,19 @@
+'use client';
+
 import React from 'react';
-import { OrderHistoryItemType } from '@/types/support';
+import { OrderDetailItemType, OrderHistoryItemType } from '@/types/support';
 import Image from 'next/image';
+import OrderDetail from './OrderDetail';
+import { TiArrowSortedDown } from 'react-icons/ti';
 
 interface OrderItemProps {
-  order: OrderHistoryItemType;
+  orderInfo: OrderHistoryItemType;
+  orderDetail: OrderDetailItemType;
+  onHandleOrderItemClick: () => void;
+  isTabMenuOpen: boolean;
 }
 
-const getStatusColor = (status: OrderHistoryItemType['orderStatus']) => {
+const getStatusColor = (status: OrderHistoryItemType['deliveryStatus']) => {
   switch (status) {
     case '배달중':
       return 'text-textRed';
@@ -17,43 +24,60 @@ const getStatusColor = (status: OrderHistoryItemType['orderStatus']) => {
   }
 };
 
-const OrderItem = ({ order }: OrderItemProps) => {
-  const statusColor = getStatusColor(order.orderStatus);
+const OrderItem = ({
+  orderInfo,
+  orderDetail,
+  onHandleOrderItemClick,
+  isTabMenuOpen,
+}: OrderItemProps) => {
+  const statusColor = getStatusColor(orderInfo.deliveryStatus);
 
   return (
-    <button
-      type="button"
-      className="w-full px-5 py-4 flex flex-col gap-5 items-start border-b border-zinc-100 hover:bg-gray-100"
-      onClick={() => console.log(`${order.orderNumber} 클릭`)}
-    >
-      <header className="flex gap-2 items-center">
-        <span className="text-textBlack text-base font-medium">
-          {order.orderDate}
-        </span>
-        <span className="text-textBlack text-base font-medium">•</span>
-        <span className={`text-base font-semibold ${statusColor}`}>
-          {order.orderStatus}
-        </span>
-      </header>
+    <>
+      <button
+        type="button"
+        className={`w-full px-5 py-4 flex flex-col gap-5 items-start border-b border-zinc-100 hover:bg-gray-100 ${
+          isTabMenuOpen ? 'border-b-0' : ''
+        }`}
+        onClick={onHandleOrderItemClick}
+      >
+        <header className="flex items-center justify-between w-full">
+          <div className="flex flex-row gap-2 items-center">
+            <span className="text-textBlack text-base font-medium">
+              {orderInfo.orderDate}
+            </span>
+            <span className="text-textBlack text-base font-medium">•</span>
+            <span className={`text-base font-semibold ${statusColor}`}>
+              {orderInfo.deliveryStatus}
+            </span>
+          </div>
+          <TiArrowSortedDown
+            className={`w-5 h-5 transition-transform duration-200 ${
+              isTabMenuOpen ? 'rotate-180' : ''
+            }`}
+          />
+        </header>
 
-      <main className="flex gap-3 items-center justify-between">
-        <Image
-          width={56}
-          height={56}
-          src={order.storeImage}
-          alt={order.storeName}
-          className="w-14 h-14 rounded-[10px]"
-        />
-        <div className="flex flex-col gap-1 items-start">
-          <span className="text-textBlack text-base font-medium">
-            {order.storeName}
-          </span>
-          <span className="text-textGray text-base font-medium whitespace-nowrap">
-            주문 번호 {order.orderNumber}
-          </span>
-        </div>
-      </main>
-    </button>
+        <main className="flex gap-3 items-center justify-between">
+          <Image
+            width={56}
+            height={56}
+            src={orderInfo.storeImage}
+            alt={orderInfo.storeName}
+            className="w-14 h-14 rounded-[10px]"
+          />
+          <div className="flex flex-col gap-1 items-start">
+            <span className="text-textBlack text-base font-medium">
+              {orderInfo.storeName}
+            </span>
+            <span className="text-textGray text-base font-medium whitespace-nowrap">
+              주문 번호 {orderInfo.orderNumber}
+            </span>
+          </div>
+        </main>
+      </button>
+      {isTabMenuOpen && <OrderDetail orderDetail={orderDetail} />}
+    </>
   );
 };
 

--- a/src/types/support.ts
+++ b/src/types/support.ts
@@ -34,10 +34,40 @@ export interface ClientInfoType {
 
 export interface OrderHistoryItemType {
   orderDate: string;
-  orderStatus: string;
+  deliveryStatus: string;
   storeName: string;
   storeImage: string;
   orderNumber: string;
+}
+
+export interface OrderDetailItemType {
+  orderNumber: string;
+  orderDate: string;
+  deliveryStatus: string;
+  orderMenuSummary: {
+    orderMenuInfos: {
+      menuName: string;
+      menuQuantity: number;
+      menuPrice: number;
+      totalMenuPrice: number;
+    }[];
+    totalPrice: number;
+  };
+  paymentInfo: {
+    paidAmount: number;
+    method: string;
+    totalAmount: number;
+    menuPrice: number;
+    deliveryFee: number;
+    discountAmount: number;
+    couponAmount: number;
+  };
+  deliveryInfo: {
+    phone: string;
+    address: string;
+    deliveryNote: string;
+    restaurantNote: string;
+  };
 }
 
 export interface ChatHistoryItemType {


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #25 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1. OrderItem 컴포넌트에 토글 아이콘 추가
- 주문 아이템에 상세 정보 열림 여부 표시를 위한 드롭다운 아이콘 추가

### 2. DetailTabs 컴포넌트 구현
- 주문 메뉴, 결제 정보, 배달 정보 탭 UI 및 상태 관리

### 3. DetailContent 컴포넌트 구현
- 탭에 따라 각 상세 정보 섹션 렌더링

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| OrderItem (isOpen = true) | OrderItem (isOpen = false) |
|--|--|
|<img width="415" height="310" alt="스크린샷 2025-07-15 오전 12 11 20" src="https://github.com/user-attachments/assets/e00929e1-9758-4df0-b137-d0d23bd9d4ff" /> | <img width="418" height="311" alt="스크린샷 2025-07-15 오전 12 11 35" src="https://github.com/user-attachments/assets/22e1c13f-83ff-42e5-a6d5-02c778b2b351" /> |

| DetailTabs - 주문 메뉴 | DetailTabs - 결제 정보 | DetailTabs - 배달 정보 |
|--|--|--|
|<img width="416" height="183" alt="스크린샷 2025-07-15 오전 12 11 51" src="https://github.com/user-attachments/assets/0abfc8f2-adbb-4eed-9e50-64fb89fd8300" /> | <img width="417" height="287" alt="스크린샷 2025-07-15 오전 12 12 07" src="https://github.com/user-attachments/assets/8ab09d9f-5c37-4ad5-8935-f1af7478b949" /> | <img width="414" height="311" alt="스크린샷 2025-07-15 오전 12 12 26" src="https://github.com/user-attachments/assets/094475c5-40ac-4b2f-8f1d-0b323959b857" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
