### PR TITLE
[Feat] ConfirmDeleteAccountModal 컴포넌트 구현

### DIFF
--- a/src/app/(main)/account/edit/page.tsx
+++ b/src/app/(main)/account/edit/page.tsx
@@ -5,6 +5,7 @@ import Header from '@/components/common/Header';
 import SectionHeader from '@/components/support/SectionHeader';
 import EditForm from '@/components/account/EditForm';
 import ProfileImage from '@/components/account/ProfileImage';
+import ConfirmDeleteAccountModal from '@/components/account/ConfirmDeleteAccountModal';
 
 export default function AccountEditPage() {
   const [userData, setUserData] = useState({
@@ -44,6 +45,12 @@ export default function AccountEditPage() {
     };
     input.click();
   };
+  const [isConfirmDeleteAccountModalOpen, setIsConfirmDeleteAccountModalOpen] =
+    useState(false);
+
+  const handleDeleteAccount = () => {
+    setIsConfirmDeleteAccountModalOpen(true);
+  };
 
   return (
     <div>
@@ -60,11 +67,20 @@ export default function AccountEditPage() {
           onEditSubmit={onEditSubmit}
         />
         <div className="max-w-[420px] mx-auto mt-6">
-          <button className="text-xs font-medium rounded-full underline text-textLightGray">
+          <button
+            className="text-xs font-medium rounded-full underline text-textLightGray"
+            onClick={handleDeleteAccount}
+          >
             탈퇴하기
           </button>
         </div>
       </div>
+      {isConfirmDeleteAccountModalOpen && (
+        <ConfirmDeleteAccountModal
+          open={isConfirmDeleteAccountModalOpen}
+          onOpenChange={setIsConfirmDeleteAccountModalOpen}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/account/ConfirmDeleteAccountModal.tsx
+++ b/src/components/account/ConfirmDeleteAccountModal.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import CustomModal from '@/components/common/CustomModal';
+import { ConfirmDeleteAccountModalPropsType } from '@/types/account';
+import { IoAlertCircle } from 'react-icons/io5';
+import { useRouter } from 'next/navigation';
+
+const ConfirmDeleteAccountModal = ({
+  open,
+  onOpenChange,
+}: ConfirmDeleteAccountModalPropsType) => {
+  const router = useRouter();
+
+  const handleDeleteAccount = () => {
+    router.push('/login');
+    onOpenChange(false);
+  };
+
+  return (
+    <CustomModal open={open} onOpenChange={onOpenChange} mode="center">
+      <div className="p-6">
+        <div className="flex flex-col items-center gap-4">
+          <IoAlertCircle color="#F06969" className="w-24 h-24" />
+          <div className="flex flex-col items-center">
+            <span className="text-texBlack text-2xl font-bold">
+              정말 탈퇴하시겠어요?
+            </span>
+            <span className="text-sm font-medium text-textLightGray">
+              계정을 삭제하면 모든 데이터가 삭제되며 복구할 수 없어요.
+            </span>
+          </div>
+        </div>
+        <div className="flex flex-col items-center gap-3 py-5 px-6">
+          <button
+            className="px-5 py-2.5 text-textBlack font-semibold rounded-full text-lg w-full border-lineGray border"
+            onClick={() => onOpenChange(false)}
+          >
+            취소
+          </button>
+          <button
+            className="px-5 py-2.5 text-white bg-textRed font-semibold rounded-full text-lg w-full"
+            onClick={handleDeleteAccount}
+          >
+            계속 탈퇴하기
+          </button>
+        </div>
+      </div>
+    </CustomModal>
+  );
+};
+
+export default ConfirmDeleteAccountModal;

--- a/src/components/common/CustomModal.tsx
+++ b/src/components/common/CustomModal.tsx
@@ -23,6 +23,7 @@ const CustomModal = ({
       case 'top-right':
         return '!left-auto !top-12 !right-16 !translate-x-0 !translate-y-0 m-0 max-w-md w-full max-h-[calc(100vh-2rem)] overflow-y-auto w-[380px]';
       case 'center':
+        return 'w-[400px]';
       default:
         return '';
     }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-3xl',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-3xl',
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-6 w-6" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -47,3 +47,8 @@ export interface MyInfoModalPropsType {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
+
+export interface ConfirmDeleteAccountModalPropsType {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
closed #45 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
### 1. ConfirmDeleteAccountModal 컴포넌트 구현 
- `CustomModal` 기반의 `ConfirmDeleteAccountModal` 컴포넌트 구현
- 계정 탈퇴 기능 포함

**UI 구성**
> 탈퇴 경고 메시지 
> "취소" 버튼 → 모달 닫힘
> "계속 탈퇴하기" 버튼 → 탈퇴 후 /login 페이지로 이동

**라우팅**
> useRouter 사용하여 페이지 이동 처리 (계속 탈퇴하기)

**CustomModal 활용**
> mode="center"로 위치 지정


## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| ConfirmDeleteAccountModal | 
|--|
| <img width="1000" height="987" alt="스크린샷 2025-08-12 오후 5 03 44" src="https://github.com/user-attachments/assets/e85f33af-5517-4b4a-8262-f0dee2810c45" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
