### PR TITLE
[Fix] 초기 렌더에서 발생하는 API 호출 실패 오류 해결

### DIFF
--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -3,9 +3,6 @@ import { LoginFormPropsType } from '@/types/auth';
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-const accessToken =
-  typeof window !== 'undefined' ? localStorage.getItem('accessToken') : null;
-
 interface SignupData {
   loginId: string;
   password: string;
@@ -66,6 +63,10 @@ export const postLogin = async (data: LoginFormPropsType['loginFormData']) => {
 
 export const getUserInfo = async () => {
   try {
+    const accessToken =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('accessToken')
+        : null;
     const response = await axios.get(`${API_URL}/members/me`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });

--- a/src/components/common/CustomModal.tsx
+++ b/src/components/common/CustomModal.tsx
@@ -43,7 +43,10 @@ const CustomModal = ({
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogPortal>
         <DialogOverlay className={getOverlayClasses()} />
-        <DialogContent className={getModalClasses()}>
+        <DialogContent
+          className={getModalClasses()}
+          aria-describedby={undefined}
+        >
           <DialogClose className="absolute right-6 focus:outline-none"></DialogClose>
           <DialogTitle className="sr-only">Modal</DialogTitle>
           {children}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -27,7 +27,11 @@ export default function Header() {
       const response = await getUserInfo();
       setUserInfo(response.data);
     };
-    fetchUserInfo();
+    const token =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('accessToken')
+        : null;
+    if (token) fetchUserInfo();
   }, []);
 
   return (
@@ -69,7 +73,6 @@ export default function Header() {
                 'https://i.pinimg.com/736x/d5/cc/bb/d5ccbb3c0796509fdaa7696da65cc8e2.jpg'
               }
               alt="profile"
-              // fill
               width={30}
               height={30}
               unoptimized={true}


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- Closed #86 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
초기 렌더 시 Header 마운트 시점과, 유저 프로필 사진을 표시하기 위해 호출하는 유저 정보 API 호출 시점이 맞지 않아 401 에러가 발생
- [X] 유저 정보 API 호출 시점마다 토큰을 읽어오도록 설정
- [X] Header 컴포넌트 마운트 시 토큰이 있는 경우에만 유저 정보 API를 호출하도록 설정하려 해결.

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->
