### PR TITLE
[Design] 리포트 상세 페이지 카테고리 스타일 분기

### DIFF
--- a/src/api/support/chatRoomPanelApi.ts
+++ b/src/api/support/chatRoomPanelApi.ts
@@ -68,3 +68,20 @@ export const getRecommendations = async (sessionId: number) => {
     throw error;
   }
 };
+
+export const triggerReport = async (targetDate: string) => {
+  try {
+    const response = await axios.post(
+      `${API_URL}/reports/generate-reports-direct?targetDate=${targetDate}`,
+      {},
+      {
+        headers: { Authorization: `Bearer ${accessToken}` },
+      },
+    );
+    console.log('리포트 생성', response.data);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    // throw error;
+  }
+};

--- a/src/components/report/detail/ReportInfo.tsx
+++ b/src/components/report/detail/ReportInfo.tsx
@@ -70,7 +70,7 @@ const ReportInfo = ({ reportDetail }: { reportDetail: ReportDetailType }) => {
         <InfoItem
           icon={<FileText className="w-5 h-5" />}
           label="상담 유형"
-          value={<Badge size="sm">{`${data.category} 문의`}</Badge>}
+          value={<Badge>{`${data.category} 문의`}</Badge>}
         />
         <InfoItem
           icon={<Phone className="w-5 h-5" />}

--- a/src/components/report/detail/ReportInfo.tsx
+++ b/src/components/report/detail/ReportInfo.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import { Undo2, Clock, UserCheck, Phone, FileText } from 'lucide-react';
 import { ReportDetailType } from '@/types/reports';
+import Badge from '@/components/common/Badge';
 import { useRouter } from 'next/navigation';
 
 type InfoItemProps = {
@@ -69,11 +70,7 @@ const ReportInfo = ({ reportDetail }: { reportDetail: ReportDetailType }) => {
         <InfoItem
           icon={<FileText className="w-5 h-5" />}
           label="상담 유형"
-          value={
-            <span className="bg-bgLightBlue text-mainColor text-xs px-2 py-1 rounded-full font-semibold w-fit">
-              {data.category} 문의
-            </span>
-          }
+          value={<Badge size="sm">{`${data.category} 문의`}</Badge>}
         />
         <InfoItem
           icon={<Phone className="w-5 h-5" />}

--- a/src/components/report/detail/SummaryBox.tsx
+++ b/src/components/report/detail/SummaryBox.tsx
@@ -9,7 +9,7 @@ const SummaryBox = ({ summaryText }: { summaryText: string }) => {
         <div className="text-base font-bold text-textBlack">상담 내용 요약</div>
       </div>
       <div className="w-full h-full pt-2">
-        <p className="text-sm text-textBlack font-medium flex-wrap break-keep overflow-y-auto max-h-14">
+        <p className="text-sm text-textBlack font-medium flex-wrap break-keep overflow-y-auto max-h-14 whitespace-pre-line">
           {summaryText}
         </p>
       </div>

--- a/src/components/report/detail/SummaryBox.tsx
+++ b/src/components/report/detail/SummaryBox.tsx
@@ -9,7 +9,7 @@ const SummaryBox = ({ summaryText }: { summaryText: string }) => {
         <div className="text-base font-bold text-textBlack">상담 내용 요약</div>
       </div>
       <div className="w-full h-full pt-2">
-        <p className="text-sm text-textBlack font-medium flex-wrap break-keep overflow-y-auto max-h-14 whitespace-pre-line">
+        <p className="text-sm text-textBlack font-medium break-keep overflow-y-auto max-h-14 whitespace-pre-line">
           {summaryText}
         </p>
       </div>

--- a/src/components/support/chatRoom/ChatRoomPanel.tsx
+++ b/src/components/support/chatRoom/ChatRoomPanel.tsx
@@ -124,9 +124,6 @@ const ChatRoomPanel = ({
     setIsEndConfirmModalOpen(true);
   };
 
-  const targetDate = new Date().toISOString().split('T')[0];
-  // console.log('targetDate', targetDate);
-
   const handleConfirmEnd = async () => {
     if (validSessionId == null) return;
     try {
@@ -134,7 +131,14 @@ const ChatRoomPanel = ({
       setSuccessMessage(response.message || '상담이 종료되었습니다.');
       setIsEndSuccessModalOpen(true);
       setIsEndConfirmModalOpen(false);
-      await triggerReport(targetDate);
+      const now = new Date();
+      const y = now.getFullYear();
+      const m = String(now.getMonth() + 1).padStart(2, '0');
+      const d = String(now.getDate()).padStart(2, '0');
+      const targetDate = `${y}-${m}-${d}`; // 한국 기준 로컬 시간
+      void triggerReport(targetDate).catch((err) => {
+        console.error('리포트 생성 실패', err);
+      });
     } catch (e) {
       console.error(e);
       setIsEndConfirmModalOpen(false);

--- a/src/components/support/chatRoom/ChatRoomPanel.tsx
+++ b/src/components/support/chatRoom/ChatRoomPanel.tsx
@@ -15,6 +15,7 @@ import {
   getChatHeaderInfo,
   getChatMessage,
   patchEndChat,
+  triggerReport,
 } from '@/api/support/chatRoomPanelApi';
 import { validateSessionId } from '@/lib/utils';
 import { useChatSocket } from '@/hooks/support/useChatSocket';
@@ -123,6 +124,9 @@ const ChatRoomPanel = ({
     setIsEndConfirmModalOpen(true);
   };
 
+  const targetDate = new Date().toISOString().split('T')[0];
+  // console.log('targetDate', targetDate);
+
   const handleConfirmEnd = async () => {
     if (validSessionId == null) return;
     try {
@@ -130,6 +134,7 @@ const ChatRoomPanel = ({
       setSuccessMessage(response.message || '상담이 종료되었습니다.');
       setIsEndSuccessModalOpen(true);
       setIsEndConfirmModalOpen(false);
+      await triggerReport(targetDate);
     } catch (e) {
       console.error(e);
       setIsEndConfirmModalOpen(false);


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- Closed #104 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- [x] 리포트 상세 페이지 카테고리 스타일 분기 설정
- [x] 상담 종료 시 리포트 생성 트리거 적용

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 상담 종료 시 해당 일자 기준으로 리포트 생성을 자동으로 트리거합니다(실패 시 로그만 남기고 흐름에는 영향 없음).
* 스타일
  * 리포트 상세의 상담 유형 표시를 배지 형태로 개선해 가독성 향상.
  * 요약 본문에 줄바꿈·공백이 그대로 반영되어 읽기 편의성 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->