### PR TITLE
[Feat] 상담원 정보 수정 API 연동

### DIFF
--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -165,9 +165,9 @@ export const patchUserPassword = async (
       switch (status) {
         case 400:
           if (code === 'MEMBER_003') {
-            throw message;
+            throw message + '\n다시 시도해주세요.';
           } else if (code === 'MEMBER_006') {
-            throw message;
+            throw message + '\n다시 시도해주세요.';
           }
         default:
           throw '비밀번호 변경 중 오류가 발생했습니다.\n다시 시도해주세요.';

--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { LoginFormPropsType } from '@/types/auth';
+import { ChangePasswordFormPropsType } from '@/types/account';
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
@@ -140,5 +141,38 @@ export const patchUserProfileInfo = async (data: {
       }
     }
     throw '프로필 수정 중 오류가 발생했습니다.\n다시 시도해주세요.';
+  }
+};
+
+export const patchUserPassword = async (
+  data: ChangePasswordFormPropsType['passwordData'],
+) => {
+  try {
+    const accessToken =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('accessToken')
+        : null;
+    const response = await axios.patch(`${API_URL}/members/me/password`, data, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const code = error.response?.data?.code;
+      const message = error.response?.data?.message;
+      switch (status) {
+        case 400:
+          if (code === 'MEMBER_003') {
+            throw message;
+          } else if (code === 'MEMBER_006') {
+            throw message;
+          }
+        default:
+          throw '비밀번호 변경 중 오류가 발생했습니다.\n다시 시도해주세요.';
+      }
+    }
+    throw '비밀번호 변경 중 오류가 발생했습니다.\n다시 시도해주세요.';
   }
 };

--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -96,3 +96,49 @@ export const postLogout = async () => {
     throw error;
   }
 };
+
+export const patchUserProfileInfo = async (data: {
+  name: string;
+  phone: string;
+  email: string;
+  currentPassword: string;
+  profileImage?: File;
+}) => {
+  try {
+    const accessToken =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('accessToken')
+        : null;
+
+    const formData = new FormData();
+    formData.append('name', data.name);
+    formData.append('phone', data.phone);
+    formData.append('email', data.email);
+    formData.append('currentPassword', data.currentPassword);
+
+    if (data.profileImage) {
+      formData.append('profileImage', data.profileImage);
+    }
+
+    const response = await axios.patch(`${API_URL}/members/me`, formData, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    console.log(response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const code = error.response?.data?.code;
+      const message = error.response?.data?.message;
+      switch (code) {
+        case 'MEMBER_006':
+          throw message;
+        default:
+          throw '프로필 수정 중 오류가 발생했습니다.\n다시 시도해주세요.';
+      }
+    }
+    throw '프로필 수정 중 오류가 발생했습니다.\n다시 시도해주세요.';
+  }
+};

--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -127,7 +127,7 @@ export const patchUserProfileInfo = async (data: {
         'Content-Type': 'multipart/form-data',
       },
     });
-    console.log(response.data);
+    // console.log(response.data);
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {

--- a/src/app/(main)/account/edit/page.tsx
+++ b/src/app/(main)/account/edit/page.tsx
@@ -4,47 +4,64 @@ import React, { useState, useEffect } from 'react';
 import Header from '@/components/common/Header';
 import SectionHeader from '@/components/support/SectionHeader';
 import EditForm from '@/components/account/EditForm';
-import ProfileImage from '@/components/account/ProfileImage';
 import ConfirmDeleteAccountModal from '@/components/account/ConfirmDeleteAccountModal';
-import { getUserInfo } from '@/api/accountApi';
-import { UserInfoType, EditUserData } from '@/types/account';
+import CustomModal from '@/components/common/modal/CustomModal';
+import { SingleConfirmButton } from '@/components/common/modal/ModalButtonGroup';
+import { getUserInfo, patchUserProfileInfo } from '@/api/accountApi';
+import { UserInfoType, EditFormPropsType } from '@/types/account';
 
 export default function AccountEditPage() {
-  const [userData, setUserData] = useState<EditUserData>({
+  const [userData, setUserData] = useState<EditFormPropsType['userData']>({
     name: '',
     phone: '',
     email: '',
-    password: '',
-    profileImageUrl: '',
+    currentPassword: '',
+    profileImage: null,
   });
+  const [currentProfileImageUrl, setCurrentProfileImageUrl] =
+    useState<string>('');
+  const [isProfileEditModalOpen, setIsProfileEditModalOpen] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+  const [isSuccess, setIsSuccess] = useState(true);
 
   const onEditChange =
-    (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    (key: 'name' | 'phone' | 'email' | 'currentPassword') =>
+    (e: React.ChangeEvent<HTMLInputElement>) => {
       setUserData({ ...userData, [key]: e.target.value });
     };
 
-  const onEditSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    console.log(userData);
+  const onProfileImageChange = (file: File) => {
+    setUserData({ ...userData, profileImage: file });
   };
 
-  const handleChangePhoto = () => {
-    // 파일 선택 dialog 열기
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = 'image/*';
-    input.onchange = (e) => {
-      const file = (e.target as HTMLInputElement).files?.[0];
-      if (file) {
-        console.log('Selected file:', file.name);
-        // 파일로 이미지 변경 구현
-        setUserData({
-          ...userData,
-          profileImageUrl: URL.createObjectURL(file),
-        });
-      }
-    };
-    input.click();
+  const onEditSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    try {
+      await patchUserProfileInfo({
+        name: userData.name,
+        phone: userData.phone,
+        email: userData.email,
+        currentPassword: userData.currentPassword,
+        profileImage: userData.profileImage || undefined,
+      });
+      setModalMessage('프로필 정보가 성공적으로 수정되었습니다.');
+      setIsSuccess(true);
+      setIsProfileEditModalOpen(true);
+      // 비밀번호 필드만 초기화
+      setUserData((prev) => ({ ...prev, currentPassword: '' }));
+
+      // 헤더의 사용자 정보 업데이트를 위한 이벤트 발생
+      window.dispatchEvent(new CustomEvent('userInfoUpdated'));
+    } catch (error) {
+      // accountApi.ts에서 처리된 에러 메시지 사용
+      const errorMessage =
+        typeof error === 'string'
+          ? { error: error + '\n다시 시도해주세요.' }
+          : { error: '프로필 수정에 실패했습니다.\n다시 시도해주세요.' };
+      setModalMessage(errorMessage.error);
+      setIsSuccess(false);
+      setIsProfileEditModalOpen(true);
+    }
   };
   const [isConfirmDeleteAccountModalOpen, setIsConfirmDeleteAccountModalOpen] =
     useState(false);
@@ -61,9 +78,10 @@ export default function AccountEditPage() {
         name: data.name,
         phone: data.phoneNum,
         email: data.email,
-        password: '',
-        profileImageUrl: data.profileImageUrl,
+        currentPassword: '',
+        profileImage: null,
       });
+      setCurrentProfileImageUrl(data.profileImageUrl);
     };
     fetchUserInfo();
   }, []);
@@ -73,16 +91,11 @@ export default function AccountEditPage() {
       <Header />
       <SectionHeader title="내 정보 수정" />
       <div className="py-6">
-        <ProfileImage
-          profileImageUrl={
-            userData.profileImageUrl ||
-            'https://i.pinimg.com/736x/d5/cc/bb/d5ccbb3c0796509fdaa7696da65cc8e2.jpg'
-          }
-          onChangePhoto={handleChangePhoto}
-        />
         <EditForm
           userData={userData}
+          currentProfileImageUrl={currentProfileImageUrl}
           onEditChange={onEditChange}
+          onProfileImageChange={onProfileImageChange}
           onEditSubmit={onEditSubmit}
         />
         <div className="max-w-[420px] mx-auto mt-6">
@@ -99,6 +112,32 @@ export default function AccountEditPage() {
           open={isConfirmDeleteAccountModalOpen}
           onOpenChange={setIsConfirmDeleteAccountModalOpen}
         />
+      )}
+      {isProfileEditModalOpen && (
+        <CustomModal
+          open={isProfileEditModalOpen}
+          onOpenChange={setIsProfileEditModalOpen}
+          mode="center"
+          isAlert={isSuccess}
+          isWarning={!isSuccess}
+        >
+          <div className="text-center p-8 bg-bgLightBlue rounded-b-3xl">
+            <div className="pb-8">
+              <p
+                className={`text-lg font-semibold whitespace-pre-line ${
+                  isSuccess ? 'text-textBlack' : 'text-textRed'
+                }`}
+              >
+                {modalMessage}
+              </p>
+            </div>
+            <SingleConfirmButton
+              onConfirm={() => setIsProfileEditModalOpen(false)}
+              confirmText="확인"
+              variant={isSuccess ? 'confirm' : 'warning'}
+            />
+          </div>
+        </CustomModal>
       )}
     </div>
   );

--- a/src/app/(main)/account/edit/password/page.tsx
+++ b/src/app/(main)/account/edit/password/page.tsx
@@ -3,23 +3,62 @@
 import Header from '@/components/common/Header';
 import SectionHeader from '@/components/support/SectionHeader';
 import ChangePasswordForm from '@/components/account/password/ChangePasswordForm';
+import CustomModal from '@/components/common/modal/CustomModal';
+import { SingleConfirmButton } from '@/components/common/modal/ModalButtonGroup';
 import { usePasswordForm } from '@/hooks/account/usePasswordForm';
 
 export default function PasswordChangePage() {
-  const { passwordData, errors, onPasswordChange, handleSubmit, disabled } =
-    usePasswordForm();
+  const {
+    passwordData,
+    errors,
+    onPasswordChange,
+    handleSubmit,
+    disabled,
+    isPasswordChangeModalOpen,
+    modalMessage,
+    isSuccess,
+    setIsPasswordChangeModalOpen,
+  } = usePasswordForm();
 
   return (
-    <div>
-      <Header />
-      <SectionHeader title="비밀번호 변경" />
-      <ChangePasswordForm
-        passwordData={passwordData}
-        errors={errors}
-        onPasswordChange={onPasswordChange}
-        onChangePasswordSubmit={handleSubmit}
-        disabled={disabled}
-      />
-    </div>
+    <>
+      <div>
+        <Header />
+        <SectionHeader title="비밀번호 변경" />
+        <ChangePasswordForm
+          passwordData={passwordData}
+          errors={errors}
+          onPasswordChange={onPasswordChange}
+          onChangePasswordSubmit={handleSubmit}
+          disabled={disabled}
+        />
+      </div>
+      {isPasswordChangeModalOpen && (
+        <CustomModal
+          open={isPasswordChangeModalOpen}
+          onOpenChange={setIsPasswordChangeModalOpen}
+          mode="center"
+          isAlert={isSuccess}
+          isWarning={!isSuccess}
+        >
+          <div className="text-center p-8 bg-bgLightBlue rounded-b-3xl">
+            <div className="pb-8">
+              <p
+                className={`text-lg font-semibold whitespace-pre-line ${
+                  isSuccess ? 'text-textBlack' : 'text-textRed'
+                }`}
+              >
+                {modalMessage}
+              </p>
+            </div>
+            <SingleConfirmButton
+              onConfirm={() => setIsPasswordChangeModalOpen(false)}
+              confirmText="확인"
+              variant={isSuccess ? 'confirm' : 'warning'}
+            />
+          </div>
+        </CustomModal>
+      )}
+    </>
   );
 }

--- a/src/components/account/EditForm.tsx
+++ b/src/components/account/EditForm.tsx
@@ -1,21 +1,39 @@
 import React from 'react';
 import InputField from '../auth/InputField';
+import ProfileImage from './ProfileImage';
 import { EditFormPropsType } from '@/types/account';
 import { useRouter } from 'next/navigation';
 
 const EditForm = ({
   userData,
+  currentProfileImageUrl,
   onEditChange,
+  onProfileImageChange,
   onEditSubmit,
 }: EditFormPropsType) => {
   const router = useRouter();
 
-  // 현재 비밀번호 input 비어있는지 확인
-  const isPasswordEmpty = !userData.password || userData.password.trim() === '';
+  const isPasswordEmpty =
+    !userData.currentPassword || userData.currentPassword.trim() === '';
+
+  // 프로필 이미지 URL 생성
+  const getProfileImageUrl = () => {
+    if (userData.profileImage) {
+      return URL.createObjectURL(userData.profileImage);
+    }
+    return (
+      currentProfileImageUrl ||
+      'https://i.pinimg.com/736x/d5/cc/bb/d5ccbb3c0796509fdaa7696da65cc8e2.jpg'
+    );
+  };
 
   return (
     <div className="w-full max-w-[420px] mx-auto py-4">
       <form className="flex flex-col gap-4 h-full" onSubmit={onEditSubmit}>
+        <ProfileImage
+          profileImageUrl={getProfileImageUrl()}
+          onChangePhoto={onProfileImageChange}
+        />
         <InputField
           type="text"
           value={userData.name}
@@ -40,8 +58,8 @@ const EditForm = ({
         <InputField
           placeholder="정보를 안전하게 보호하기 위해 비밀번호를 입력해주세요."
           type="password"
-          value={userData.password}
-          onChange={onEditChange('password')}
+          value={userData.currentPassword}
+          onChange={onEditChange('currentPassword')}
           inputLabel="현재 비밀번호"
           isSignup
         />

--- a/src/components/account/EditForm.tsx
+++ b/src/components/account/EditForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import InputField from '../auth/InputField';
 import ProfileImage from './ProfileImage';
 import { EditFormPropsType } from '@/types/account';
@@ -12,26 +12,29 @@ const EditForm = ({
   onEditSubmit,
 }: EditFormPropsType) => {
   const router = useRouter();
+  const [previewUrl, setPreviewUrl] = useState<string>('');
 
   const isPasswordEmpty =
     !userData.currentPassword || userData.currentPassword.trim() === '';
 
   // 프로필 이미지 URL 생성
-  const getProfileImageUrl = () => {
+  useEffect(() => {
     if (userData.profileImage) {
-      return URL.createObjectURL(userData.profileImage);
+      const url = URL.createObjectURL(userData.profileImage);
+      setPreviewUrl(url);
+      return () => URL.revokeObjectURL(url);
     }
-    return (
+    return setPreviewUrl(
       currentProfileImageUrl ||
-      'https://i.pinimg.com/736x/d5/cc/bb/d5ccbb3c0796509fdaa7696da65cc8e2.jpg'
+        'https://i.pinimg.com/736x/d5/cc/bb/d5ccbb3c0796509fdaa7696da65cc8e2.jpg',
     );
-  };
+  }, [userData.profileImage, currentProfileImageUrl]);
 
   return (
     <div className="w-full max-w-[420px] mx-auto py-4">
       <form className="flex flex-col gap-4 h-full" onSubmit={onEditSubmit}>
         <ProfileImage
-          profileImageUrl={getProfileImageUrl()}
+          profileImageUrl={previewUrl}
           onChangePhoto={onProfileImageChange}
         />
         <InputField

--- a/src/components/account/ProfileImage.tsx
+++ b/src/components/account/ProfileImage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { ProfileImagePropsType } from '@/types/account';
 import Image from 'next/image';
 
@@ -6,6 +6,19 @@ const ProfileImage = ({
   profileImageUrl,
   onChangePhoto,
 }: ProfileImagePropsType) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFileSelect = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      onChangePhoto(file);
+    }
+  };
+
+  const handleButtonClick = () => {
+    fileInputRef.current?.click();
+  };
+
   return (
     <div className="max-w-[420px] mx-auto flex items-center justify-start gap-6 mb-2">
       <div className="w-20 h-20 border border-lineGray rounded-full flex items-center justify-center">
@@ -19,11 +32,18 @@ const ProfileImage = ({
       </div>
       <button
         type="button"
-        onClick={onChangePhoto}
+        onClick={handleButtonClick}
         className="px-6 py-2 text-l font-semibold rounded-full border border-lineGray text-textBlack hover:bg-gray-50"
       >
         사진 변경하기
       </button>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        onChange={handleFileSelect}
+        className="hidden"
+      />
     </div>
   );
 };

--- a/src/components/account/ProfileImage.tsx
+++ b/src/components/account/ProfileImage.tsx
@@ -23,7 +23,10 @@ const ProfileImage = ({
     <div className="max-w-[420px] mx-auto flex items-center justify-start gap-6 mb-2">
       <div className="w-20 h-20 border border-lineGray rounded-full flex items-center justify-center">
         <Image
-          src={profileImageUrl}
+          src={
+            profileImageUrl ||
+            'https://i.pinimg.com/736x/d5/cc/bb/d5ccbb3c0796509fdaa7696da65cc8e2.jpg'
+          }
           alt="profile"
           width={82}
           height={82}

--- a/src/components/account/password/ChangePasswordForm.tsx
+++ b/src/components/account/password/ChangePasswordForm.tsx
@@ -41,12 +41,12 @@ const ChangePasswordForm = ({
           <div>
             <InputField
               type="password"
-              value={passwordData.newPasswordConfirm}
-              onChange={onPasswordChange('newPasswordConfirm')}
+              value={passwordData.confirmPassword}
+              onChange={onPasswordChange('confirmPassword')}
               inputLabel="새 비밀번호 확인"
               placeholder="새 비밀번호를 다시 입력해주세요."
               isSignup
-              errorMessage={errors.newPasswordConfirm}
+              errorMessage={errors.confirmPassword}
             />
           </div>
         </div>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -28,14 +28,30 @@ export default function Header({ showNavItems = true }: HeaderProps) {
 
   useEffect(() => {
     const fetchUserInfo = async () => {
-      const response = await getUserInfo();
-      setUserInfo(response.data);
+      try {
+        const response = await getUserInfo();
+        setUserInfo(response.data);
+      } catch (error) {
+        console.error('사용자 정보 가져오기 실패:', error);
+      }
     };
+
     const token =
       typeof window !== 'undefined'
         ? localStorage.getItem('accessToken')
         : null;
     if (token) fetchUserInfo();
+
+    // 사용자 정보 업데이트 이벤트 리스너
+    const handleUserInfoUpdate = () => {
+      if (token) fetchUserInfo();
+    };
+
+    window.addEventListener('userInfoUpdated', handleUserInfoUpdate);
+
+    return () => {
+      window.removeEventListener('userInfoUpdated', handleUserInfoUpdate);
+    };
   }, []);
 
   return (

--- a/src/hooks/account/usePasswordForm.ts
+++ b/src/hooks/account/usePasswordForm.ts
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react';
 import { PASSWORD_CHANGE_ERROR_MESSAGES } from '@/lib/constants/errorMessages';
+import { patchUserPassword } from '@/api/accountApi';
 
 // 비밀번호 유효성 검사 함수
 function validatePassword(password: string): boolean {
@@ -82,6 +83,11 @@ export const usePasswordForm = () => {
     confirmPassword: '',
   });
 
+  const [modalMessage, setModalMessage] = useState('');
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [isPasswordChangeModalOpen, setIsPasswordChangeModalOpen] =
+    useState(false);
+
   // 전체 폼 유효성 검사
   const validateForm = (): boolean => {
     const newErrors: PasswordErrors = {
@@ -118,13 +124,36 @@ export const usePasswordForm = () => {
     };
 
   // submit 핸들러
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     if (validateForm()) {
-      console.log('비밀번호 변경 API 연결 필요:', passwordData);
-
-      return true;
+      try {
+        await patchUserPassword(passwordData);
+        setPasswordData({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+        });
+        setErrors({
+          currentPassword: '',
+          newPassword: '',
+          confirmPassword: '',
+        });
+        setModalMessage('비밀번호가 성공적으로 변경되었습니다.');
+        setIsSuccess(true);
+        setIsPasswordChangeModalOpen(true);
+        return true;
+      } catch (error) {
+        const errorMessage =
+          typeof error === 'string'
+            ? { error: error + '\n다시 시도해주세요.' }
+            : { error: '비밀번호 변경에 실패했습니다.\n다시 시도해주세요.' };
+        setModalMessage(errorMessage.error);
+        setIsSuccess(false);
+        setIsPasswordChangeModalOpen(true);
+        return false;
+      }
     } else {
       console.log('유효성 검사 실패');
       return false;
@@ -155,5 +184,9 @@ export const usePasswordForm = () => {
     handleSubmit,
     isFormValid,
     disabled,
+    modalMessage,
+    isSuccess,
+    isPasswordChangeModalOpen,
+    setIsPasswordChangeModalOpen,
   };
 };

--- a/src/hooks/account/usePasswordForm.ts
+++ b/src/hooks/account/usePasswordForm.ts
@@ -27,13 +27,13 @@ function validateDifferentPassword(
 interface PasswordData {
   currentPassword: string;
   newPassword: string;
-  newPasswordConfirm: string;
+  confirmPassword: string;
 }
 
 interface PasswordErrors {
   currentPassword: string;
   newPassword: string;
-  newPasswordConfirm: string;
+  confirmPassword: string;
 }
 
 // 필드별 유효성 검사 함수
@@ -57,7 +57,7 @@ const validateField = (
         return PASSWORD_CHANGE_ERROR_MESSAGES.SAME_AS_CURRENT;
       }
       return '';
-    case 'newPasswordConfirm':
+    case 'confirmPassword':
       if (!value)
         return PASSWORD_CHANGE_ERROR_MESSAGES.EMPTY_NEW_PASSWORD_CONFIRM;
       if (!validatePasswordConfirm(data.newPassword, value)) {
@@ -73,13 +73,13 @@ export const usePasswordForm = () => {
   const [passwordData, setPasswordData] = useState<PasswordData>({
     currentPassword: '',
     newPassword: '',
-    newPasswordConfirm: '',
+    confirmPassword: '',
   });
 
   const [errors, setErrors] = useState<PasswordErrors>({
     currentPassword: '',
     newPassword: '',
-    newPasswordConfirm: '',
+    confirmPassword: '',
   });
 
   // 전체 폼 유효성 검사
@@ -95,9 +95,9 @@ export const usePasswordForm = () => {
         passwordData.newPassword,
         passwordData,
       ),
-      newPasswordConfirm: validateField(
-        'newPasswordConfirm',
-        passwordData.newPasswordConfirm,
+      confirmPassword: validateField(
+        'confirmPassword',
+        passwordData.confirmPassword,
         passwordData,
       ),
     };
@@ -136,7 +136,7 @@ export const usePasswordForm = () => {
     return (
       passwordData.currentPassword &&
       passwordData.newPassword &&
-      passwordData.newPasswordConfirm &&
+      passwordData.confirmPassword &&
       !Object.values(errors).some((error) => error !== '')
     );
   };

--- a/src/hooks/account/usePasswordForm.ts
+++ b/src/hooks/account/usePasswordForm.ts
@@ -147,9 +147,9 @@ export const usePasswordForm = () => {
       } catch (error) {
         const errorMessage =
           typeof error === 'string'
-            ? { error: error + '\n다시 시도해주세요.' }
-            : { error: '비밀번호 변경에 실패했습니다.\n다시 시도해주세요.' };
-        setModalMessage(errorMessage.error);
+            ? error
+            : '비밀번호 변경에 실패했습니다.\n다시 시도해주세요.';
+        setModalMessage(errorMessage);
         setIsSuccess(false);
         setIsPasswordChangeModalOpen(true);
         return false;

--- a/src/hooks/account/usePasswordForm.ts
+++ b/src/hooks/account/usePasswordForm.ts
@@ -155,7 +155,7 @@ export const usePasswordForm = () => {
         return false;
       }
     } else {
-      console.log('유효성 검사 실패');
+      // console.log('유효성 검사 실패');
       return false;
     }
   };

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -3,17 +3,20 @@ export interface EditFormPropsType {
     name: string;
     phone: string;
     email: string;
-    password: string;
+    currentPassword: string;
+    profileImage?: File | null;
   };
+  currentProfileImageUrl?: string;
   onEditChange: (
-    key: string,
+    key: 'name' | 'phone' | 'email' | 'currentPassword',
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onProfileImageChange: (file: File) => void;
   onEditSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
 export interface ProfileImagePropsType {
   profileImageUrl: string;
-  onChangePhoto: () => void;
+  onChangePhoto: (file: File) => void;
 }
 
 export interface ChangePasswordFormPropsType {

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -23,15 +23,15 @@ export interface ChangePasswordFormPropsType {
   passwordData: {
     currentPassword: string;
     newPassword: string;
-    newPasswordConfirm: string;
+    confirmPassword: string;
   };
   errors: {
     currentPassword: string;
     newPassword: string;
-    newPasswordConfirm: string;
+    confirmPassword: string;
   };
   onPasswordChange: (
-    key: 'currentPassword' | 'newPassword' | 'newPasswordConfirm',
+    key: 'currentPassword' | 'newPassword' | 'confirmPassword',
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
   onChangePasswordSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
   disabled: boolean;


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- Closed #106 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 상담원 정보 수정 API 연동을 구현했습니다.
1. 상담원 프로필 정보 수정
2. 상담원 비밀번호 수정 

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->
| 비밀번호 변경 성공 | 비밀번호 변경 실패 |
|--|--|
| <img width="1552" height="981" alt="스크린샷 2025-10-12 오후 11 51 35" src="https://github.com/user-attachments/assets/4332c1d7-2b16-4898-9945-a19e1080b311" /> |  <img width="1552" height="981" alt="스크린샷 2025-10-12 오후 11 51 10" src="https://github.com/user-attachments/assets/8afb5560-128f-4d2d-ad7c-96b3704d773c" /> |


| 상담원 정보 수정 성공 | 상담원 정보 수정 실패 |
|--|--|
| <img width="1552" height="981" alt="스크린샷 2025-10-12 오후 11 52 36" src="https://github.com/user-attachments/assets/dec20d72-918f-4017-8e9d-265994448208" /> | <img width="1552" height="981" alt="스크린샷 2025-10-12 오후 11 52 25" src="https://github.com/user-attachments/assets/1902057a-52a8-42f8-8158-f76ba7a80247" /> |


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 계정 편집에서 프로필 사진 업로드·미리보기 지원 및 저장 시 성공/실패 모달 제공
  - 비밀번호 변경 완료·실패 모달 추가로 결과를 즉시 안내
  - 프로필 정보·비밀번호 변경용 API 호출 및 오류 메시지 처리 개선으로 저장 피드백 명확화
- Refactor
  - 편집 폼과 비밀번호 폼의 필드명·데이터 흐름 정리(확인 비밀번호 명칭 통일 등)
  - 초기 로딩·상태 관리 단순화 및 이벤트 기반 사용자 정보 갱신으로 UI 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->