### PR TITLE
[Feat] 상담원 탈퇴 API 연동

### DIFF
--- a/src/api/accountApi.ts
+++ b/src/api/accountApi.ts
@@ -176,3 +176,27 @@ export const patchUserPassword = async (
     throw '비밀번호 변경 중 오류가 발생했습니다.\n다시 시도해주세요.';
   }
 };
+
+export const deleteUser = async () => {
+  try {
+    const accessToken =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('accessToken')
+        : null;
+    const response = await axios.delete(`${API_URL}/members/me`, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    // console.log(response.data);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const status = error.response?.status;
+      const message = error.response?.data?.message;
+      switch (status) {
+        case 400:
+          throw message;
+      }
+    }
+    throw error;
+  }
+};

--- a/src/components/account/ConfirmDeleteAccountModal.tsx
+++ b/src/components/account/ConfirmDeleteAccountModal.tsx
@@ -3,6 +3,7 @@ import CustomModal from '@/components/common/modal/CustomModal';
 import { ConfirmCancelButtons } from '@/components/common/modal/ModalButtonGroup';
 import { ConfirmDeleteAccountModalPropsType } from '@/types/account';
 import { useRouter } from 'next/navigation';
+import { deleteUser } from '@/api/accountApi';
 
 const ConfirmDeleteAccountModal = ({
   open,
@@ -10,10 +11,15 @@ const ConfirmDeleteAccountModal = ({
 }: ConfirmDeleteAccountModalPropsType) => {
   const router = useRouter();
 
-  const handleDeleteAccount = () => {
-    localStorage.clear();
-    router.push('/login');
-    onOpenChange(false);
+  const handleDeleteAccount = async () => {
+    try {
+      await deleteUser();
+      localStorage.clear();
+      router.push('/login');
+      onOpenChange(false);
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (

--- a/src/components/account/ConfirmDeleteAccountModal.tsx
+++ b/src/components/account/ConfirmDeleteAccountModal.tsx
@@ -15,8 +15,11 @@ const ConfirmDeleteAccountModal = ({
   const router = useRouter();
   const [isFailModalOpen, setIsFailModalOpen] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string>('');
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleDeleteAccount = async () => {
+    if (isDeleting) return;
+    setIsDeleting(true);
     try {
       await deleteUser();
       localStorage.clear();
@@ -28,6 +31,8 @@ const ConfirmDeleteAccountModal = ({
         '네트워크 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.',
       );
       setIsFailModalOpen(true);
+    } finally {
+      setIsDeleting(false);
     }
   };
 

--- a/src/components/account/ConfirmDeleteAccountModal.tsx
+++ b/src/components/account/ConfirmDeleteAccountModal.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, { useState } from 'react';
 import CustomModal from '@/components/common/modal/CustomModal';
-import { ConfirmCancelButtons } from '@/components/common/modal/ModalButtonGroup';
+import {
+  ConfirmCancelButtons,
+  SingleConfirmButton,
+} from '@/components/common/modal/ModalButtonGroup';
 import { ConfirmDeleteAccountModalPropsType } from '@/types/account';
 import { useRouter } from 'next/navigation';
 import { deleteUser } from '@/api/accountApi';
@@ -10,6 +13,8 @@ const ConfirmDeleteAccountModal = ({
   onOpenChange,
 }: ConfirmDeleteAccountModalPropsType) => {
   const router = useRouter();
+  const [isFailModalOpen, setIsFailModalOpen] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>('');
 
   const handleDeleteAccount = async () => {
     try {
@@ -19,35 +24,64 @@ const ConfirmDeleteAccountModal = ({
       onOpenChange(false);
     } catch (error) {
       console.error(error);
+      setErrorMessage(
+        '네트워크 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.',
+      );
+      setIsFailModalOpen(true);
     }
   };
 
   return (
-    <CustomModal
-      open={open}
-      onOpenChange={onOpenChange}
-      mode="center"
-      isWarning={true}
-    >
-      <div className="text-center p-8 bg-[#F9EEEE] rounded-b-3xl">
-        <div className="pb-8">
-          <p className="font-bold text-textBlack text-xl mb-4">
-            정말 탈퇴하시겠어요?
-          </p>
-          <p className="text-textGray text-base font-medium">
-            계정을 삭제하면 모든 데이터가 삭제되며 <br />
-            복구할 수 없어요.
-          </p>
+    <>
+      <CustomModal
+        open={open}
+        onOpenChange={onOpenChange}
+        mode="center"
+        isWarning={true}
+      >
+        <div className="text-center p-8 bg-[#F9EEEE] rounded-b-3xl">
+          <div className="pb-8">
+            <p className="font-bold text-textBlack text-xl mb-4">
+              정말 탈퇴하시겠어요?
+            </p>
+            <p className="text-textGray text-base font-medium">
+              계정을 삭제하면 모든 데이터가 삭제되며 <br />
+              복구할 수 없어요.
+            </p>
+          </div>
+          <ConfirmCancelButtons
+            onCancel={() => onOpenChange(false)}
+            onConfirm={handleDeleteAccount}
+            cancelText="취소"
+            confirmText="계속 탈퇴하기"
+            confirmVariant="warning"
+          />
         </div>
-        <ConfirmCancelButtons
-          onCancel={() => onOpenChange(false)}
-          onConfirm={handleDeleteAccount}
-          cancelText="취소"
-          confirmText="계속 탈퇴하기"
-          confirmVariant="warning"
-        />
-      </div>
-    </CustomModal>
+      </CustomModal>
+
+      <CustomModal
+        open={isFailModalOpen}
+        onOpenChange={setIsFailModalOpen}
+        mode="center"
+        isWarning={true}
+      >
+        <div className="text-center p-8 bg-[#F9EEEE] rounded-b-3xl">
+          <div className="pb-8">
+            <p className="font-bold text-textRed text-xl mb-4">
+              탈퇴 처리에 실패했습니다
+            </p>
+            <p className="text-textGray text-base font-medium whitespace-pre-line">
+              {errorMessage || '잠시 후 다시 시도해주세요.'}
+            </p>
+          </div>
+          <SingleConfirmButton
+            onConfirm={() => setIsFailModalOpen(false)}
+            confirmText="확인"
+            variant="warning"
+          />
+        </div>
+      </CustomModal>
+    </>
   );
 };
 


### PR DESCRIPTION
## 📌 Related Issues
<!-- 관련 이슈 -->
- Closed #111 

## ✨ Work Description
<!-- 작업한 부분에 대해 설명해주세요. -->
- 상담원 탈퇴 API 연동을 구현했습니다. 

## 📢 Notices
<!-- 리뷰어가 집중해서 봐줬으면 하는 부분이 있다면 작성해주세요. -->


## 📷 ScreenShot
<!-- UI 변경이 있다면 스크린샷 첨부해주세요. -->


## 📚 Reference
<!-- 참고한 아티클 링크 / 새롭게 알게 된 점이 있다면 적어주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 서버 연동을 통해 계정 삭제를 실행하는 기능이 추가되었습니다.
  - 삭제 실패 시 별도 오류 모달로 상세 메시지를 보여주는 UI가 추가되었습니다.

- 개선
  - 계정 삭제 흐름이 비동기 처리로 안정화되었습니다.
  - 오류 발생 시 사용자에게 친절한 안내와 재확인 흐름이 제공됩니다.
  - 삭제 성공 시 데이터 정리 후 로그인 화면으로 이동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->